### PR TITLE
Remove use of raw type Class to suppress warning in use code

### DIFF
--- a/src/main/java/com/treasuredata/underwrap/UnderwrapServer.java
+++ b/src/main/java/com/treasuredata/underwrap/UnderwrapServer.java
@@ -76,7 +76,7 @@ public class UnderwrapServer
         this.accessLogPath = accessLogPath;
     }
 
-    private void deploy(Map<Class, Object> contextMap, DeploymentBuild deploymentBuild)
+    private void deploy(Map<Class<?>, Object> contextMap, DeploymentBuild deploymentBuild)
     {
         // Construct deployment information
         ResteasyDeployment resteasyDeployment = new ResteasyDeployment();
@@ -125,7 +125,7 @@ public class UnderwrapServer
 
         // Set instances we want to pass via @Context annotation
         if (contextMap != null) {
-            for (Map.Entry<Class, Object> contextTuple : contextMap.entrySet()) {
+            for (Map.Entry<Class<?>, Object> contextTuple : contextMap.entrySet()) {
                 resteasyDeployment.getDispatcher().getDefaultContextObjects().put(contextTuple.getKey(), contextTuple.getValue());
             }
         }
@@ -144,7 +144,7 @@ public class UnderwrapServer
         undertow.start();
     }
 
-    public void start(Map<Class, Object> contextMap, DeploymentBuild deploymentBuild, ServerBuild serverBuild)
+    public void start(Map<Class<?>, Object> contextMap, DeploymentBuild deploymentBuild, ServerBuild serverBuild)
     {
         deploy(contextMap, deploymentBuild);
         buildAndStartServer(serverBuild);


### PR DESCRIPTION
Use of raw type `Map<Class, Object>` causes warning in user project code:
```
Server.java:56: warning: [rawtypes] found raw type: Class
                     ImmutableMap.<Class, Object>builder()
                                   ^
  missing type arguments for generic class Class<T>
  where T is a type-variable:
    T extends Object declared in class Class
```

Defining argument in use code as `Map<Class<?>, Object>` causes compile error. So it should be fixed in library side.