### PR TITLE
PLT-10518: add a metric to get queue capacity

### DIFF
--- a/src/main/java/com/treasuredata/underwrap/UnderwrapMetrics.java
+++ b/src/main/java/com/treasuredata/underwrap/UnderwrapMetrics.java
@@ -77,4 +77,17 @@ public class UnderwrapMetrics
         }
         // TODO: use `worker.getMXBean().getWorkerQueueSize()` when Xnio 3.5 or later available
     }
+
+    public int getWorkerQueueCapacity()
+    {
+        // return taskQueue.remainingCapacity();
+        try {
+            Field field = XnioWorker.class.getDeclaredField("taskQueue");
+            field.setAccessible(true);
+            return ((BlockingQueue) field.get(worker)).remainingCapacity();
+        }
+        catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException("BUG: incompatible accesse", e);
+        }
+    }
 }


### PR DESCRIPTION
This change is to observer HTTP requests (and its processing task) are stack in BlockingQueue, or not.
Once we get clear insight on it, we can omit this metric from list of metrics ordinary exported.
